### PR TITLE
Add support for variable $TDCREATE.

### DIFF
--- a/drw_header.cpp
+++ b/drw_header.cpp
@@ -944,9 +944,9 @@ void DRW_Header::write(dxfWriter *writer, DRW::Version ver){
         writer->writeInt16(70, varInt);
     } else
         writer->writeInt16(70, 6);
-    writer->writeString(9, "$TDCREATE");
-    if (getInt("$TDCREATE", &varInt)) {
-        writer->writeInt16(40, varInt);
+    if (getStr("$TDCREATE", &varStr)) {
+        writer->writeString(9, "$TDCREATE");
+        writer->writeString(40, varStr);
     }
     if (ver > DRW::AC1009) {
     writer->writeString(9, "$UCSBASE");

--- a/drw_header.cpp
+++ b/drw_header.cpp
@@ -944,6 +944,10 @@ void DRW_Header::write(dxfWriter *writer, DRW::Version ver){
         writer->writeInt16(70, varInt);
     } else
         writer->writeInt16(70, 6);
+    writer->writeString(9, "$TDCREATE");
+    if (getInt("$TDCREATE", &varInt)) {
+        writer->writeInt16(40, varInt);
+    }
     if (ver > DRW::AC1009) {
     writer->writeString(9, "$UCSBASE");
     if (getStr("$UCSBASE", &varStr))


### PR DESCRIPTION
According to documentation $TDCREATE has code 40 and contains "Local date/time of drawing creation (see “Special Handling of Date/Time Variables”)". 