### PR TITLE
DRW_Coord: Simplify constructor/assignment.

### DIFF
--- a/drw_base.h
+++ b/drw_base.h
@@ -166,15 +166,11 @@ enum TransparencyCodes {
 */
 class DRW_Coord {
 public:
-    DRW_Coord() { x = 0; y = 0; z = 0; }
+    DRW_Coord() = default;
     DRW_Coord(double ix, double iy, double iz) {
         x = ix; y = iy; z = iz;
     }
 
-     DRW_Coord operator = (const DRW_Coord& data) {
-        x = data.x;  y = data.y;  z = data.z;
-        return *this;
-    }
 /*!< convert to unitary vector */
     void unitize(){
         double dist;
@@ -187,9 +183,9 @@ public:
     }
 
 public:
-    double x;
-    double y;
-    double z;
+    double x = 0;
+    double y = 0;
+    double z = 0;
 };
 
 


### PR DESCRIPTION
Having a user-specified assignment operator but default copy-constructor
violates rule of 2/3/5/0.

Found by clazy.