### PR TITLE
Rename DEBUG enum as Debug.

### DIFF
--- a/drw_base.h
+++ b/drw_base.h
@@ -94,9 +94,9 @@ BAD_READ_ENTITIES,    /*!< error in entities read process. */
 BAD_READ_OBJECTS      /*!< error in objects read process. */
 };
 
-enum DBG_LEVEL {
-    NONE,
-    DEBUG
+enum DebugLevel {
+    None,
+    Debug
 };
 
 //! Special codes for colors

--- a/drw_entities.cpp
+++ b/drw_entities.cpp
@@ -1270,7 +1270,7 @@ bool DRW_LWPolyline::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
             }
         }
     }
-    if (DRW_DBGGL == DRW_dbg::DEBUG){
+    if (DRW_DBGGL == DRW_dbg::Debug){
         DRW_DBG("\nVertex list: ");
         for (std::vector<DRW_Vertex2D *>::iterator it = vertlist.begin() ; it != vertlist.end(); ++it){
             DRW_Vertex2D* pv = *it;
@@ -2210,7 +2210,7 @@ bool DRW_Spline::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
         DRW_Coord* crd = new DRW_Coord(buf->get3BitDouble());
         fitlist.push_back (crd);
     }
-    if (DRW_DBGGL == DRW_dbg::DEBUG){
+    if (DRW_DBGGL == DRW_dbg::Debug){
         DRW_DBG("\nknots list: ");
         for (std::vector<double>::iterator it = knotslist.begin() ; it != knotslist.end(); ++it){
             DRW_DBG("\n"); DRW_DBG(*it);

--- a/drw_header.cpp
+++ b/drw_header.cpp
@@ -2392,7 +2392,7 @@ bool DRW_Header::parseDwg(DRW::Version version, dwgBuffer *buf, dwgBuffer *hBbuf
     DRW_DBG("\nstring buf position: "); DRW_DBG(buf->getPosition());
     DRW_DBG("  string buf bit position: "); DRW_DBG(buf->getBitPos());
 
-    if (DRW_DBGGL == DRW_dbg::DEBUG){
+    if (DRW_DBGGL == DRW_dbg::Debug){
         for (std::map<std::string,DRW_Variant*>::iterator it=vars.begin(); it!=vars.end(); ++it){
             DRW_DBG("\n"); DRW_DBG(it->first); DRW_DBG(": ");
             switch (it->second->type){

--- a/intern/drw_dbg.cpp
+++ b/intern/drw_dbg.cpp
@@ -56,7 +56,7 @@ DRW_dbg *DRW_dbg::getInstance(){
 }
 
 DRW_dbg::DRW_dbg(){
-    level = NONE;
+    level = None;
     prClass = new print_none;
     flags = std::cerr.flags();
 }
@@ -65,7 +65,7 @@ void DRW_dbg::setLevel(LEVEL lvl){
     level = lvl;
     delete prClass;
     switch (level){
-    case DEBUG:
+    case Debug:
         prClass = new print_debug;
         break;
     default:

--- a/intern/drw_dbg.h
+++ b/intern/drw_dbg.h
@@ -31,8 +31,8 @@ class print_none;
 class DRW_dbg {
 public:
     enum LEVEL {
-        NONE,
-        DEBUG
+        None,
+        Debug
     };
     void setLevel(LEVEL lvl);
     LEVEL getLevel();

--- a/intern/dwgreader.cpp
+++ b/intern/dwgreader.cpp
@@ -615,7 +615,7 @@ bool dwgReader::readDwgTables(DRW_Header& hdr, dwgBuffer *dbuf) {
     }
 
     //RLZ: parse remaining object controls, TODO: implement all
-    if (DRW_DBGGL == DRW_dbg::DEBUG){
+    if (DRW_DBGGL == DRW_dbg::Debug){
         mit = ObjectMap.find(hdr.viewCtrl);
         if (mit==ObjectMap.end()) {
             DRW_DBG("\nWARNING: View control not found\n");
@@ -1184,7 +1184,7 @@ bool dwgReader::readDwgObjects(DRW_Interface& intfa, dwgBuffer *dbuf){
         if (ret)
             ret = ret2;
     }
-    if (DRW_DBGGL == DRW_dbg::DEBUG) {
+    if (DRW_DBGGL == DRW_dbg::Debug) {
         for (std::map<duint32, objHandle>::iterator it=remainingMap.begin(); it != remainingMap.end(); ++it){
             DRW_DBG("\nnum.# "); DRW_DBG(i++); DRW_DBG(" Remaining object Handle, loc, type= "); DRW_DBG(it->first);
             DRW_DBG(" "); DRW_DBG(it->second.loc); DRW_DBG(" "); DRW_DBG(it->second.type);

--- a/libdwgr.cpp
+++ b/libdwgr.cpp
@@ -36,7 +36,7 @@
 };*/
 
 dwgR::dwgR(){
-    DRW_DBGSL(DRW_dbg::NONE);
+    DRW_DBGSL(DRW_dbg::None);
     reader = NULL;
 //    writer = NULL;
     applyExt = false;
@@ -50,13 +50,13 @@ dwgR::~dwgR(){
 
 }
 
-void dwgR::setDebug(DRW::DBG_LEVEL lvl){
+void dwgR::setDebug(DRW::DebugLevel lvl){
     switch (lvl){
-    case DRW::DEBUG:
-        DRW_DBGSL(DRW_dbg::DEBUG);
+    case DRW::Debug:
+        DRW_DBGSL(DRW_dbg::Debug);
         break;
     default:
-        DRW_DBGSL(DRW_dbg::NONE);
+        DRW_DBGSL(DRW_dbg::None);
     }
 }
 

--- a/libdwgr.h
+++ b/libdwgr.h
@@ -31,7 +31,7 @@ public:
     bool getPreview(std::istream &stream);
     DRW::Version getVersion(){return version;}
     DRW::error getError(){return error;}
-    void setDebug(DRW::DBG_LEVEL lvl);
+    void setDebug(DRW::DebugLevel lvl);
 
 private:
     bool open(std::istream *stream);

--- a/libdxfrw.cpp
+++ b/libdxfrw.cpp
@@ -33,7 +33,7 @@
 };*/
 
 dxfRW::dxfRW(){
-    DRW_DBGSL(DRW_dbg::NONE);
+    DRW_DBGSL(DRW_dbg::None);
     reader = NULL;
     writer = NULL;
     applyExt = false;
@@ -50,13 +50,13 @@ dxfRW::~dxfRW(){
     imageDef.clear();
 }
 
-void dxfRW::setDebug(DRW::DBG_LEVEL lvl){
+void dxfRW::setDebug(DRW::DebugLevel lvl){
     switch (lvl){
-    case DRW::DEBUG:
-        DRW_DBGSL(DRW_dbg::DEBUG);
+    case DRW::Debug:
+        DRW_DBGSL(DRW_dbg::Debug);
         break;
     default:
-        DRW_DBGSL(DRW_dbg::NONE);
+        DRW_DBGSL(DRW_dbg::None);
     }
 }
 

--- a/libdxfrw.h
+++ b/libdxfrw.h
@@ -27,7 +27,7 @@ class dxfRW {
 public:
     dxfRW();
     ~dxfRW();
-    void setDebug(DRW::DBG_LEVEL lvl);
+    void setDebug(DRW::DebugLevel lvl);
     /// reads the file specified in constructor
     /*!
      * An interface must be provided. It is used by the class to signal various


### PR DESCRIPTION
This avoids a conflict with the commonly used DEBUG build macro.

The names match the change made to https://github.com/LibreCAD/libdxfrw in commit [6c094ba](https://github.com/LibreCAD/libdxfrw/commit/6c094ba).